### PR TITLE
Use release branch of CoreCLR and fix resulting breakages.

### DIFF
--- a/BuildDeps.cmd
+++ b/BuildDeps.cmd
@@ -19,7 +19,7 @@ goto Usage
 
 :BuildCoreCLR
 pushd coreclr
-call build.cmd %__BuildArch% %__BuildType%
+call build.cmd %__BuildArch% %__BuildType% skipmscorlib skiptests
 IF ERRORLEVEL 1 goto Error
 
 mkdir ..\Libs\%__BuildType%\%__BuildArch%\

--- a/Patches/CoreCLR/DiffCoreCLR.bat
+++ b/Patches/CoreCLR/DiffCoreCLR.bat
@@ -2,9 +2,15 @@
 REM ########################################################
 echo Gathering changes to disable COM interop support in CoreCLR...
 pushd ..\..\CoreCLR
+git diff v1.0.0-rc2 src\inc\ex.h > ..\Patches\CoreCLR\src\inc\ex.h
 git diff v1.0.0-rc2 src\inc\utilcode.h > ..\Patches\CoreCLR\src\inc\utilcode.h
-git diff v1.0.0-rc2 src\utilcode\CMakeLists.txt > ..\Patches\CoreCLR\src\utilcode\CMakeLists.txt
+git diff v1.0.0-rc2 src\utilcode\posterror.cpp > ..\Patches\CoreCLR\src\utilcode\posterror.cpp
 git diff v1.0.0-rc2 src\utilcode\util.cpp > ..\Patches\CoreCLR\src\utilcode\util.cpp
+git diff v1.0.0-rc2 src\utilcode\CMakeLists.txt > ..\Patches\CoreCLR\src\utilcode\CMakeLists.txt
+git diff v1.0.0-rc2 src\vm\clrex.cpp > ..\Patches\CoreCLR\src\vm\clrex.cpp
+git diff v1.0.0-rc2 src\vm\comcache.cpp > ..\Patches\CoreCLR\src\vm\comcache.cpp
+git diff v1.0.0-rc2 src\vm\interoputil.cpp > ..\Patches\CoreCLR\src\vm\interoputil.cpp
+git diff v1.0.0-rc2 src\vm\threads.cpp > ..\Patches\CoreCLR\src\vm\threads.cpp
 git diff v1.0.0-rc2 src\CMakeLists.txt > ..\Patches\CoreCLR\src\CMakeLists.txt
 git diff v1.0.0-rc2 build.cmd > ..\Patches\CoreCLR\build.cmd
 git diff v1.0.0-rc2 clr.coreclr.props > ..\Patches\CoreCLR\clr.coreclr.props

--- a/Patches/CoreCLR/clr.coreclr.props
+++ b/Patches/CoreCLR/clr.coreclr.props
@@ -1,5 +1,5 @@
 diff --git a/clr.coreclr.props b/clr.coreclr.props
-index a335486..4568d24 100644
+index a335486..510a296 100644
 --- a/clr.coreclr.props
 +++ b/clr.coreclr.props
 @@ -10,7 +10,7 @@
@@ -27,3 +27,12 @@ index a335486..4568d24 100644
      <FeatureHostAssemblyResolver>true</FeatureHostAssemblyResolver>
      <FeatureLazyCOWPages Condition="('$(TargetArch)' == 'i386') or ('$(TargetArch)' == 'arm')">true</FeatureLazyCOWPages>
      <FeatureLatin1>true</FeatureLatin1>
+@@ -76,7 +76,7 @@
+     <FeatureManagedEtwChannels>true</FeatureManagedEtwChannels>
+     <FeatureHostedBinder>true</FeatureHostedBinder>
+     <BinderDebugLog Condition="'$(_BuildType)'=='dbg'">true</BinderDebugLog>
+-    <FeatureAppX>true</FeatureAppX>
++    <FeatureAppX>false</FeatureAppX>
+     <FeatureWinMDResilient>true</FeatureWinMDResilient>
+     <!-- 
+         FeatureImplicitTls has been verified to be functionally correct on x86 & amd64.


### PR DESCRIPTION
* Use release/1.0.0-rc2 branch of CoreCLR, and fix resulting breakages
* Don't build mscorlib because it's not needed for Pyjion

Note that all references to SetErrorInfo have been removed. I'm not sure what the knock-on effects of that are, but it does seem to line up with the the original patch author's intent.