### PR TITLE
Remove reference to mscoree from longfilepathwrappers

### DIFF
--- a/PatchDeps.bat
+++ b/PatchDeps.bat
@@ -6,6 +6,7 @@ echo Disabling COM interop support in CoreCLR...
 pushd CoreCLR
 git apply ..\Patches\CoreCLR\src\inc\utilcode.h
 git apply ..\Patches\CoreCLR\src\utilcode\CMakeLists.txt
+git apply ..\Patches\CoreCLR\src\utilcode\longfilepathwrappers.cpp
 git apply ..\Patches\CoreCLR\src\utilcode\util.cpp
 git apply ..\Patches\CoreCLR\src\CMakeLists.txt
 git apply ..\Patches\CoreCLR\build.cmd

--- a/Patches/CoreCLR/src/utilcode/longfilepathwrappers.cpp
+++ b/Patches/CoreCLR/src/utilcode/longfilepathwrappers.cpp
@@ -1,0 +1,26 @@
+diff --git a/src/utilcode/longfilepathwrappers.cpp b/src/utilcode/longfilepathwrappers.cpp
+index 2b5a8b4..54c8e09 100644
+--- a/src/utilcode/longfilepathwrappers.cpp
++++ b/src/utilcode/longfilepathwrappers.cpp
+@@ -1190,10 +1190,6 @@ FindFirstFileExWrapper(
+ 
+ #ifndef FEATURE_PAL
+ 
+-#if ! defined(DACCESS_COMPILE) && !defined(SELF_NO_HOST)
+-extern HINSTANCE            g_pMSCorEE;
+-#endif// ! defined(DACCESS_COMPILE) && !defined(SELF_NO_HOST)
+-
+ BOOL PAL_GetPALDirectoryWrapper(SString& pbuffer)
+ {
+ 
+@@ -1203,10 +1199,6 @@ BOOL PAL_GetPALDirectoryWrapper(SString& pbuffer)
+     DWORD dwPath; 
+     HINSTANCE hinst = NULL;
+ 
+-#if ! defined(DACCESS_COMPILE) && !defined(SELF_NO_HOST)
+-    hinst = g_pMSCorEE;
+-#endif// ! defined(DACCESS_COMPILE) && !defined(SELF_NO_HOST)
+-
+ #ifndef CROSSGEN_COMPILE
+     _ASSERTE(hinst != NULL);
+ #endif


### PR DESCRIPTION
Resolves linker error (LNK2001): `unresolved external symbol "struct HINSTANCE__ * g_pMSCorEE" (?g_pMSCorEE@@3PEAUHINSTANCE__@@EA)` in `utilcode.lib` (`longfilepathwrappers.obj`).