### PR TITLE
Implement OPT-1

### DIFF
--- a/Tests/test_emission.cpp
+++ b/Tests/test_emission.cpp
@@ -60,8 +60,9 @@ private:
     }
 
 public:
-    explicit EmissionTest(const char *code) {
+    explicit EmissionTest(const char *code, unsigned short optLevel = 0) {
         PyErr_Clear();
+        setOptimizationLevel(optLevel);
         m_code.reset(CompileCode(code));
         if (m_code.get() == nullptr) {
             FAIL("failed to compile in JIT code");
@@ -302,9 +303,15 @@ TEST_CASE("Dict Merging"){
 }
 
 TEST_CASE("General is comparison") {
+    auto optLevel  = GENERATE(0, 1, 2);
     SECTION("common case") {
-        auto t = EmissionTest("def f(): return 1 is 2");
+        auto t = EmissionTest("def f(): return 1 is 2", optLevel);
         CHECK(t.returns() == "False");
+    }
+
+    SECTION("common not case") {
+        auto t = EmissionTest("def f(): return 1 is not 2", optLevel);
+        CHECK(t.returns() == "True");
     }
 }
 

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -1221,14 +1221,17 @@ void PythonCompiler::emit_is(bool isNot) {
     if (g_pyjionSettings.opt_inlineIs){
         auto branchType = isNot ? BranchNotEqual : BranchEqual;
         Label match = emit_define_label();
+        Label end = emit_define_label();
         emit_branch(branchType, match);
         emit_ptr(Py_False);
         emit_dup();
         emit_incref();
+        emit_branch(BranchAlways, end);
         emit_mark_label(match);
         emit_ptr(Py_True);
         emit_dup();
         emit_incref();
+        emit_mark_label(end);
     } else {
         m_il.emit_call(isNot ? METHOD_ISNOT : METHOD_IS);
     }

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -1219,6 +1219,15 @@ void PythonCompiler::emit_binary_object(int opcode) {
 
 void PythonCompiler::emit_is(bool isNot) {
     if (g_pyjionSettings.opt_inlineIs){
+        auto left = m_il.define_local(Parameter(CORINFO_TYPE_NATIVEINT));
+        auto right = m_il.define_local(Parameter(CORINFO_TYPE_NATIVEINT));
+
+        m_il.st_loc(left);
+        m_il.st_loc(right);
+
+        m_il.ld_loc(right);
+        m_il.ld_loc(left);
+
         auto branchType = isNot ? BranchNotEqual : BranchEqual;
         Label match = emit_define_label();
         Label end = emit_define_label();
@@ -1232,6 +1241,11 @@ void PythonCompiler::emit_is(bool isNot) {
         emit_dup();
         emit_incref();
         emit_mark_label(end);
+
+        emit_load_and_free_local(left);
+        decref();
+        emit_load_and_free_local(right);
+        decref();
     } else {
         m_il.emit_call(isNot ? METHOD_ISNOT : METHOD_IS);
     }

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -33,6 +33,7 @@ typedef void(__cdecl* JITSTARTUP)(ICorJitHost*);
 #endif
 
 #include "pycomp.h"
+#include "pyjit.h"
 
 using namespace std;
 
@@ -1217,7 +1218,20 @@ void PythonCompiler::emit_binary_object(int opcode) {
 }
 
 void PythonCompiler::emit_is(bool isNot) {
-    m_il.emit_call(isNot ? METHOD_ISNOT : METHOD_IS);
+    if (g_pyjionSettings.opt_inlineIs){
+        auto branchType = isNot ? BranchNotEqual : BranchEqual;
+        Label match = emit_define_label();
+        emit_branch(branchType, match);
+        emit_ptr(Py_False);
+        emit_dup();
+        emit_incref();
+        emit_mark_label(match);
+        emit_ptr(Py_True);
+        emit_dup();
+        emit_incref();
+    } else {
+        m_il.emit_call(isNot ? METHOD_ISNOT : METHOD_IS);
+    }
 }
 
 

--- a/src/pyjion/pyjit.h
+++ b/src/pyjion/pyjit.h
@@ -59,10 +59,13 @@ PyjionJittedCode* PyJit_EnsureExtra(PyObject* codeObject);
 class PyjionJittedCode;
 typedef PyObject* (*Py_EvalFunc)(PyjionJittedCode*, struct _frame*);
 
-typedef struct {
+typedef struct PyjionSettings {
     bool tracing;
     bool profiling;
-    unsigned short optimizationLevel;
+    unsigned short optimizationLevel = 1;
+
+    // Optimizations
+    bool opt_inlineIs = true; // OPT-1
 } PyjionSettings;
 
 static PY_UINT64_T HOT_CODE = 0;
@@ -106,5 +109,7 @@ public:
 };
 
 bool jit_compile(PyCodeObject* code);
+
+void setOptimizationLevel(unsigned short level);
 
 #endif


### PR DESCRIPTION
Implements #81 

In occurrences of `a is b` (the `IS_OP` opcode) should inline a pointer (qword) comparison and a branch operation instead of calling a compiled C function.

Replaces a call to `PyJit_Is` with the following:

- QWORD compare of a and b
- Load the Py_TRUE or Py_FALSE static values
- Increment the refcount of Py_TRUE or Py_FALSE directly by doing an ADD operation on the byte offset of the PyObject 

TODO : 

- [x] Decref lhs 
- [x] DECREF rhs
