### PR TITLE
OPT-3 optimize COMPARE_OP/rich comparisons of short (interned) integers

### DIFF
--- a/CMakeOptimizations.txt
+++ b/CMakeOptimizations.txt
@@ -1,6 +1,7 @@
 # Optimization default flags
 option(OPTIMIZE_DECREF "Optimize DECREF when ob_refcnt > 1" ON)
 option(OPTIMIZE_IS "Optimize IS_OP" ON)
+option(OPTIMIZE_INTERN_COMPARE "Optimize COMPARE_OP for intern values" ON)
 
 
 if (WIN32)
@@ -18,4 +19,10 @@ if (OPTIMIZE_IS)
     add_definitions(-DOPTIMIZE_IS=1)
 else()
     add_definitions(-DOPTIMIZE_IS=0)
+endif()
+
+if (OPTIMIZE_INTERN_COMPARE)
+    add_definitions(-DOPTIMIZE_INTERN_COMPARE=1)
+else()
+    add_definitions(-DOPTIMIZE_INTERN_COMPARE=0)
 endif()

--- a/Tests/test_interns.py
+++ b/Tests/test_interns.py
@@ -1,0 +1,84 @@
+"""Test the optimization of intern values (-5 - 256)"""
+import unittest
+import pyjion
+import io
+import pyjion.dis
+import contextlib
+
+class InternIntegerTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        pyjion.enable()
+
+    def tearDown(self) -> None:
+        pyjion.disable()
+
+    def assertNotOptimized(self, func) -> None:
+        self.assertFalse(func())
+        self.assertTrue(pyjion.info(func)['compiled'])
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            pyjion.dis.dis(func)
+        self.assertIn("ldarg.1", f.getvalue())
+        self.assertIn("MethodTokens.METHOD_RICHCMP_TOKEN", f.getvalue())
+
+    def assertOptimized(self, func) -> None:
+        self.assertFalse(func())
+        self.assertTrue(pyjion.info(func)['compiled'])
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            pyjion.dis.dis(func)
+        self.assertIn("ldarg.1", f.getvalue())
+        self.assertNotIn("MethodTokens.METHOD_RICHCMP_TOKEN", f.getvalue())
+
+    def test_const_compare(self):
+        def test_f():
+            a = 1
+            b = 2
+            return a == b
+        self.assertOptimized(test_f)
+
+
+    def test_const_compare_big_left(self):
+        def test_f():
+            a = 1000
+            b = 2
+            return a == b
+
+        self.assertOptimized(test_f)
+
+    def test_const_compare_big_right(self):
+        def test_f():
+            a = 1
+            b = 2000
+            return a == b
+
+        self.assertOptimized(test_f)
+
+    def test_const_compare_big_both(self):
+        def test_f():
+            a = 1000
+            b = 2000
+            return a == b
+
+        self.assertNotOptimized(test_f)
+
+    def test_const_not_integer(self):
+        def test_f():
+            a = 2
+            b = "2"
+            return a == b
+
+        self.assertNotOptimized(test_f)
+
+    def test_float_compare(self):
+        def test_f():
+            a = 2
+            b = 1.0
+            return a == b
+
+        self.assertNotOptimized(test_f)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/pyjion/absint.h
+++ b/src/pyjion/absint.h
@@ -389,5 +389,6 @@ private:
     void incExcVars(int count);
 };
 
-
+// TODO : Fetch the range of interned integers from the interpreter state
+#define IS_SMALL_INT(ival) (-5 <= (ival) && (ival) < 257)
 #endif

--- a/src/pyjion/absvalue.cpp
+++ b/src/pyjion/absvalue.cpp
@@ -28,6 +28,7 @@
 AnyValue Any;
 UndefinedValue Undefined;
 IntegerValue Integer;
+InternIntegerValue InternInteger;
 FloatValue Float;
 BoolValue Bool;
 ListValue List;

--- a/src/pyjion/absvalue.h
+++ b/src/pyjion/absvalue.h
@@ -161,6 +161,10 @@ public:
     virtual bool isAlwaysFalse() {
         return false;
     }
+    virtual bool isIntern() {
+        return false;
+    }
+
     virtual AbstractValue* mergeWith(AbstractValue*other);
     virtual AbstractValueKind kind() = 0;
     virtual const char* describe() {
@@ -287,6 +291,9 @@ class IntegerValue : public AbstractValue {
 };
 
 class InternIntegerValue : public IntegerValue {
+    bool isIntern() override {
+        return true;
+    }
 };
 
 class StringValue : public AbstractValue {

--- a/src/pyjion/absvalue.h
+++ b/src/pyjion/absvalue.h
@@ -286,6 +286,9 @@ class IntegerValue : public AbstractValue {
     void truth(AbstractSource* sources) override;
 };
 
+class InternIntegerValue : public IntegerValue {
+};
+
 class StringValue : public AbstractValue {
     AbstractValueKind kind() override;
     AbstractValue* binary(AbstractSource* selfSources, int op, AbstractValueWithSources& other) override;
@@ -351,6 +354,7 @@ extern UndefinedValue Undefined;
 extern AnyValue Any;
 extern BoolValue Bool;
 extern IntegerValue Integer;
+extern InternIntegerValue InternInteger;
 extern FloatValue Float;
 extern ListValue List;
 extern TupleValue Tuple;

--- a/src/pyjion/ilgen.h
+++ b/src/pyjion/ilgen.h
@@ -344,6 +344,9 @@ public:
                 case BranchLessThanEqual:
                     m_il.push_back(CEE_BLE_S); // Pop1+Pop1, Push0
                     break;
+                case BranchGreaterThan:
+                    m_il.push_back(CEE_BGT_S); // Pop1+Pop1, Push0
+                    break;
             }
             m_il.push_back((BYTE)offset - 2);
         }

--- a/src/pyjion/ipycomp.h
+++ b/src/pyjion/ipycomp.h
@@ -27,6 +27,7 @@
 #define PYJION_IPYCOMP_H
 
 #include <cstdint>
+#include "absvalue.h"
 
 class Local {
 public:
@@ -358,6 +359,8 @@ public:
 
     // Performs a comparison for values on the stack which are objects, keeping a boxed Python object as the result.
     virtual void emit_compare_object(int compareType) = 0;
+    // Performs a comparison for values on the stack which are objects, keeping a boxed Python object as the result.
+    virtual void emit_compare_known_object(int compareType, AbstractValueWithSources lhs, AbstractValueWithSources rhs) = 0;
     // Performs a comparison of two unboxed floating point values on the stack
     virtual void emit_compare_float(int compareType) = 0;
     // Performs a comparison of two tagged integers

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -1326,6 +1326,10 @@ void PythonCompiler::emit_compare_object(int compareType) {
     m_il.emit_call(METHOD_RICHCMP_TOKEN);
 }
 
+void PythonCompiler::emit_compare_known_object(int compareType, AbstractValueWithSources lhs, AbstractValueWithSources rhs) {
+    emit_compare_object(compareType);
+}
+
 void PythonCompiler::emit_load_method(void* name) {
     m_il.ld_i(name);
     m_il.emit_call(METHOD_LOAD_METHOD);

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -1330,13 +1330,13 @@ void PythonCompiler::emit_compare_known_object(int compareType, AbstractValueWit
     // OPT-3 Optimize the comparison of an intern'ed const integer with an integer to an IS_OP expression.
     if ((lhs.Value->isIntern() && rhs.Value->kind() == AVK_Integer) ||
         (rhs.Value->isIntern() && lhs.Value->kind() == AVK_Integer)){
-        if (compareType == Py_EQ) {
-            emit_is(false);
-            return;
-        }
-        else if (compareType == Py_NE) {
-            emit_is(true);
-            return;
+        switch(compareType) { // NOLINT(hicpp-multiway-paths-covered)
+            case Py_EQ:
+                emit_is(false);
+                return;
+            case Py_NE:
+                emit_is(true);
+                return;
         }
     }
     emit_compare_object(compareType);

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -1327,6 +1327,18 @@ void PythonCompiler::emit_compare_object(int compareType) {
 }
 
 void PythonCompiler::emit_compare_known_object(int compareType, AbstractValueWithSources lhs, AbstractValueWithSources rhs) {
+    // OPT-3 Optimize the comparison of an intern'ed const integer with an integer to an IS_OP expression.
+    if ((lhs.Value->isIntern() && rhs.Value->kind() == AVK_Integer) ||
+        (rhs.Value->isIntern() && lhs.Value->kind() == AVK_Integer)){
+        if (compareType == Py_EQ) {
+            emit_is(false);
+            return;
+        }
+        else if (compareType == Py_NE) {
+            emit_is(true);
+            return;
+        }
+    }
     emit_compare_object(compareType);
 }
 

--- a/src/pyjion/pycomp.h
+++ b/src/pyjion/pycomp.h
@@ -377,6 +377,7 @@ public:
 
     void emit_compare_object(int compareType) override;
     void emit_compare_float(int compareType) override;
+    void emit_compare_known_object(int compareType, AbstractValueWithSources lhs, AbstractValueWithSources rhs) override;
     void emit_compare_tagged_int(int compareType) override;
 
     void emit_store_fast(int local) override;

--- a/src/pyjion/pyjit.h
+++ b/src/pyjion/pyjit.h
@@ -67,6 +67,7 @@ typedef struct PyjionSettings {
     // Optimizations
     bool opt_inlineIs = OPTIMIZE_IS; // OPT-1
     bool opt_inlineDecref = OPTIMIZE_DECREF; // OPT-2
+    bool opt_internRichCompare = OPTIMIZE_INTERN_COMPARE; // OPT-3
 } PyjionSettings;
 
 static PY_UINT64_T HOT_CODE = 0;
@@ -74,6 +75,8 @@ static PY_UINT64_T jitPassCounter = 0;
 static PY_UINT64_T jitFailCounter = 0;
 
 static PyjionSettings g_pyjionSettings;
+
+#define OPT_ENABLED(opt) g_pyjionSettings.opt_ ## opt
 
 void PyjionJitFree(void* obj);
 


### PR DESCRIPTION
Will detect const values in the byte code and mark the abstract value source as constant and the type as being interned.

In this way, the value of the integer doesn't need to be calculated, since you can assert that the number is (`IS_SMALL_INT`) exists within the interp->small_ints and the pointer reference can be compared.