### PR TITLE
Extend dump_native to output the code length and position

### DIFF
--- a/src/pyjion/__init__.pyi
+++ b/src/pyjion/__init__.pyi
@@ -10,7 +10,7 @@ def info(f: callable) -> dict:
 def dump_il(f: callable) -> bytearray:
     ...
 
-def dump_native(f: callable) -> bytearray:
+def dump_native(f: callable) -> tuple[bytearray, int, int]:
     ...
 
 def enable_tracing() -> None:
@@ -23,4 +23,7 @@ def enable_profiling() -> None:
     ...
 
 def disable_profiling() -> None:
+    ...
+
+def set_optimization_level(level: int) -> None:
     ...

--- a/src/pyjion/dis.py
+++ b/src/pyjion/dis.py
@@ -656,7 +656,7 @@ def dis_native(f):
         import distorm3
     except ImportError:
         raise ModuleNotFoundError("Install distorm3 before disassembling native functions")
-    code = dump_native(f)
-    iterable = distorm3.DecodeGenerator(0x00000000, bytes(code), distorm3.Decode64Bits)
+    code, code_length, position = dump_native(f)
+    iterable = distorm3.DecodeGenerator(position, bytes(code), distorm3.Decode64Bits)
     for (offset, size, instruction, hexdump) in iterable:
         print("%.8x: %s" % (offset, instruction))

--- a/src/pyjion/pyjit.h
+++ b/src/pyjion/pyjit.h
@@ -125,5 +125,4 @@ public:
 bool jit_compile(PyCodeObject* code);
 
 void setOptimizationLevel(unsigned short level);
-
 #endif


### PR DESCRIPTION
To aid with disassembly, change `dump_native()` to output a tuple of (bytes, Len, position)