### PR TITLE
Pretty print assembly code using rich syntax highlighting

### DIFF
--- a/Docs/source/api.rst
+++ b/Docs/source/api.rst
@@ -53,7 +53,7 @@ Disassembly module
 
 .. function:: dis_native(f)
 
-   Print the x86 assembly instructions in a disassembly table (required distorm3)
+   Print the x86 assembly instructions in a disassembly table (requires distorm3 and rich)
 
 WSGI middleware
 ---------------

--- a/Docs/source/using.rst
+++ b/Docs/source/using.rst
@@ -33,7 +33,7 @@ You can see some basic stats by running `pyjion.info(f)`, where `f` is the funct
 
 You can see the machine code for the compiled function by disassembling it in the Python REPL.
 Pyjion has essentially compiled your small Python function into a small, standalone application.
-Install `distorm3` first to disassemble x86-64 assembly and run `pyjion.dis.dis_native(f)`:
+Install `distorm3` and `rich` first to disassemble x86-64 assembly and run `pyjion.dis.dis_native(f)`:
 
 .. code-block::
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can see some basic stats by running `pyjion.info(f)`, where `f` is the funct
 
 You can see the machine code for the compiled function by disassembling it in the Python REPL.
 Pyjion has essentially compiled your small Python function into a small, standalone application.
-Install `distorm3` first to disassemble x86-64 assembly and run `pyjion.dis.dis_native(f)`:
+Install `distorm3` and `rich` first to disassemble x86-64 assembly and run `pyjion.dis.dis_native(f)`:
 
 ```
 >>> import pyjion.dis

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     packages=['pyjion'],
     package_dir={'': 'src'},
     setup_requires=setup_requires,
+    extras_require = {
+        'dis':  ["rich", "distorm3"]
+    },
     python_requires='>=3.9',
     include_package_data=True,
     long_description=long_description,


### PR DESCRIPTION
This PR closes issue #97 and adds syntax highlighting to `pyjion.dis.dis_native()`.

It also adds an [extra](https://stackoverflow.com/questions/52474931/what-is-extra-in-pypi-dependency) modifier to the package like `pyjion[dis]` that optionally requires `rich` and `distorm.

Here is an example output:
![image](https://user-images.githubusercontent.com/85785/103789490-5f2f5a80-5040-11eb-8134-104d15a41691.png)
