### PR TITLE
Mark PyjionSettings as `extern` to use as a global

### DIFF
--- a/src/pyjion/pyjit.cpp
+++ b/src/pyjion/pyjit.cpp
@@ -55,6 +55,8 @@ struct SpecializedTreeNode {
 	}
 };
 
+PyjionSettings g_pyjionSettings;
+
 #define SET_OPT(opt, actualLevel, minLevel) \
     g_pyjionSettings.opt_ ## opt = (actualLevel) >= (minLevel) ? true : false;
 

--- a/src/pyjion/pyjit.h
+++ b/src/pyjion/pyjit.h
@@ -83,7 +83,7 @@ static PY_UINT64_T HOT_CODE = 0;
 static PY_UINT64_T jitPassCounter = 0;
 static PY_UINT64_T jitFailCounter = 0;
 
-static PyjionSettings g_pyjionSettings;
+extern PyjionSettings g_pyjionSettings;
 
 #define OPT_ENABLED(opt) g_pyjionSettings.opt_ ## opt
 


### PR DESCRIPTION
Closes #167.