### PR TITLE
Refcounts integration tests for mathematical binary operations

### DIFF
--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -65,3 +65,29 @@ class BinaryOperationTestCase(unittest.TestCase):
         self.assertEqual(sys.getrefcount(b), before_ref_b)
         self.assertEqual(sys.getrefcount(c), before_ref_c - 1)
         self.assertEqual(c, 1234)
+
+    def test_floor_division(self):
+        a = 7777777
+        b = 55555
+        c = 10040
+        before_ref_a = sys.getrefcount(a)
+        before_ref_b = sys.getrefcount(b)
+        before_ref_c = sys.getrefcount(c)
+        c = a // b
+        self.assertEqual(sys.getrefcount(a), before_ref_a)
+        self.assertEqual(sys.getrefcount(b), before_ref_b)
+        self.assertEqual(sys.getrefcount(c), before_ref_c + 1)
+        self.assertEqual(c, 140)
+
+    def test_power(self):
+        a = 0.5
+        b = -8
+        c = 8401
+        before_ref_a = sys.getrefcount(a)
+        before_ref_b = sys.getrefcount(b)
+        before_ref_c = sys.getrefcount(c)
+        c = a ** b
+        self.assertEqual(sys.getrefcount(a), before_ref_a)
+        self.assertEqual(sys.getrefcount(b), before_ref_b)
+        self.assertEqual(sys.getrefcount(c), before_ref_c - 1)
+        self.assertEqual(c, 256)

--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -95,6 +95,9 @@ class BinaryOperationTestCase(unittest.TestCase):
 
 class CPythonComparison(unittest.TestCase):
 
+    def tearDown(self) -> None:
+        gc.collect()
+
     def test_floor_division(self):
         a = 7777777
         b = 55555

--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -91,3 +91,19 @@ class BinaryOperationTestCase(unittest.TestCase):
         self.assertEqual(sys.getrefcount(b), before_ref_b)
         self.assertEqual(sys.getrefcount(c), before_ref_c - 1)
         self.assertEqual(c, 256)
+
+
+class CPythonComparison(unittest.TestCase):
+
+    def test_floor_division(self):
+        a = 7777777
+        b = 55555
+        c = 10040
+        before_ref_a = sys.getrefcount(a)
+        before_ref_b = sys.getrefcount(b)
+        before_ref_c = sys.getrefcount(c)
+        c = a // b
+        self.assertEqual(sys.getrefcount(a), before_ref_a)
+        self.assertEqual(sys.getrefcount(b), before_ref_b)
+        self.assertEqual(sys.getrefcount(c), before_ref_c + 1)
+        self.assertEqual(c, 140)

--- a/Tests/test_binary.py
+++ b/Tests/test_binary.py
@@ -1,0 +1,67 @@
+import gc
+import sys
+import unittest
+
+import pyjion
+
+
+class BinaryOperationTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        pyjion.enable()
+
+    def tearDown(self) -> None:
+        pyjion.disable()
+        gc.collect()
+
+    def test_addition(self):
+        a = 987654
+        b = 123456
+        c = 192837
+        before_ref_a = sys.getrefcount(a)
+        before_ref_b = sys.getrefcount(b)
+        before_ref_c = sys.getrefcount(c)
+        c = a + b
+        self.assertEqual(sys.getrefcount(a), before_ref_a)
+        self.assertEqual(sys.getrefcount(b), before_ref_b)
+        self.assertEqual(sys.getrefcount(c), before_ref_c - 2)
+        self.assertEqual(c, 1111110)
+
+    def test_subtraction(self):
+        a = 987654
+        b = 123456
+        c = 192837
+        before_ref_a = sys.getrefcount(a)
+        before_ref_b = sys.getrefcount(b)
+        before_ref_c = sys.getrefcount(c)
+        c = a - b
+        self.assertEqual(sys.getrefcount(a), before_ref_a)
+        self.assertEqual(sys.getrefcount(b), before_ref_b)
+        self.assertEqual(sys.getrefcount(c), before_ref_c - 2)
+        self.assertEqual(c, 864198)
+
+    def test_multiplication(self):
+        a = 987
+        b = 1001
+        c = 1234321
+        before_ref_a = sys.getrefcount(a)
+        before_ref_b = sys.getrefcount(b)
+        before_ref_c = sys.getrefcount(c)
+        c = a * b
+        self.assertEqual(sys.getrefcount(a), before_ref_a)
+        self.assertEqual(sys.getrefcount(b), before_ref_b)
+        self.assertEqual(sys.getrefcount(c), before_ref_c - 1)
+        self.assertEqual(c, 987987)
+
+    def test_division(self):
+        a = 12341234
+        b = 10001
+        c = 98789
+        before_ref_a = sys.getrefcount(a)
+        before_ref_b = sys.getrefcount(b)
+        before_ref_c = sys.getrefcount(c)
+        c = a / b
+        self.assertEqual(sys.getrefcount(a), before_ref_a)
+        self.assertEqual(sys.getrefcount(b), before_ref_b)
+        self.assertEqual(sys.getrefcount(c), before_ref_c - 1)
+        self.assertEqual(c, 1234)


### PR DESCRIPTION
Add integration tests to compare refcounts before and after mathematical binary operations.

See #125 for more details.