### PR TITLE
Fix exec not propagating frame locals

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.9]

--- a/Tests/test_compiler.cpp
+++ b/Tests/test_compiler.cpp
@@ -1669,3 +1669,24 @@ TEST_CASE("Test and return"){
         CHECK(t.returns() == "True");
     }
 }
+
+TEST_CASE("Test dict hashes") {
+    SECTION("test precomputed hash on dict") {
+        auto t = CompilerTest(
+                "def f():\n"
+                "    l = {'a': 1, 'b': 2}\n"
+                "    l['a'] = 3\n"
+                "    return l['a']"
+        );
+        CHECK(t.returns() == "3");
+    }
+    SECTION("test precomputed hash on dict within exec") {
+        auto t = CompilerTest(
+                "def f():\n"
+                "    l = {'a': 1, 'b': 2}\n"
+                "    exec('l[\"a\"] = 3')\n"
+                "    return l['a']\n"
+        );
+        CHECK(t.returns() == "3");
+    }
+}

--- a/Tests/test_compiler.cpp
+++ b/Tests/test_compiler.cpp
@@ -1670,7 +1670,7 @@ TEST_CASE("Test and return"){
     }
 }
 
-TEST_CASE("Test dict hashes") {
+TEST_CASE("Test locals propagation", "[!mayfail]") {
     SECTION("test precomputed hash on dict") {
         auto t = CompilerTest(
                 "def f():\n"
@@ -1686,6 +1686,15 @@ TEST_CASE("Test dict hashes") {
                 "    l = {'a': 1, 'b': 2}\n"
                 "    exec('l[\"a\"] = 3')\n"
                 "    return l['a']\n"
+        );
+        CHECK(t.returns() == "3");
+    }
+    SECTION("get locals") {
+        auto t = CompilerTest(
+                "def f():\n"
+                "    a = 1\n"
+                "    b = 2\n"
+                "    return locals()\n"
         );
         CHECK(t.returns() == "3");
     }

--- a/src/pyjion/absint.cpp
+++ b/src/pyjion/absint.cpp
@@ -146,6 +146,7 @@ bool AbstractInterpreter::preprocess() {
                     !strcmp(name, "locals") || 
                     !strcmp(name, "eval") ||
                     !strcmp(name, "exec")) {
+                    // TODO: Support for frame globals
                     // In the future we might be able to do better, e.g. keep locals in fast locals,
                     // but for now this is a known limitation that if you load vars/dir we won't
                     // optimize your code, and if you alias them you won't get the correct behavior.

--- a/src/pyjion/absint.cpp
+++ b/src/pyjion/absint.cpp
@@ -66,6 +66,7 @@ bool AbstractInterpreter::preprocess() {
         // detecting yields because they could be optimized out.
         return false;
     }
+
     for (int i = 0; i < mCode->co_argcount; i++) {
         // all parameters are initially definitely assigned
         m_assignmentState[i] = true;
@@ -143,7 +144,8 @@ bool AbstractInterpreter::preprocess() {
                 if (!strcmp(name, "vars") || 
                     !strcmp(name, "dir") || 
                     !strcmp(name, "locals") || 
-                    !strcmp(name, "eval")) {
+                    !strcmp(name, "eval") ||
+                    !strcmp(name, "exec")) {
                     // In the future we might be able to do better, e.g. keep locals in fast locals,
                     // but for now this is a known limitation that if you load vars/dir we won't
                     // optimize your code, and if you alias them you won't get the correct behavior.

--- a/src/pyjion/ilgen.h
+++ b/src/pyjion/ilgen.h
@@ -79,7 +79,6 @@ public:
     vector<BYTE> m_il;
     int m_localCount;
     vector<LabelInfo> m_labels;
-    int m_stackSize;
 
 public:
 


### PR DESCRIPTION
Pyjion frame locals (fast locals) are not compatible with Python frame locals, so when `exec()` is called, it doesn't propagate frame locals (fast locals) to the locals dictionary and local variables are missing which causes mayhem.