### PR TITLE
Rewrite UNPACK_SEQUENCE to be more efficient and safer

### DIFF
--- a/Tests/test_compiler.cpp
+++ b/Tests/test_compiler.cpp
@@ -49,7 +49,7 @@ private:
         _PyInterpreterState_SetEvalFrameFunc(PyInterpreterState_Main(), PyJit_EvalFrame);
         auto res = PyJit_ExecuteAndCompileFrame(m_jittedcode.get(), frame, tstate, nullptr);
         _PyInterpreterState_SetEvalFrameFunc(PyInterpreterState_Main(), prev);
-        //Py_DECREF(frame);
+        Py_DECREF(frame);
         size_t collected = PyGC_Collect();
         printf("Collected %zu values\n", collected);
         REQUIRE(!m_jittedcode->j_failed);
@@ -1467,7 +1467,9 @@ TEST_CASE("Test unpacking with UNPACK_SEQUENCE", "[!mayfail]") {
                 "def f():\n    a, b = (1, 2)\n    return a, b"
         );
         CHECK(t.returns() == "(1, 2)");
-    }SECTION("Too many items to unpack from list raises valueerror") {
+    }
+
+    SECTION("Too many items to unpack from list raises valueerror") {
         auto t = CompilerTest(
                 "def f():\n    x = [1,2,3]\n    a, b = x"
         );

--- a/Tests/test_compiler.cpp
+++ b/Tests/test_compiler.cpp
@@ -87,12 +87,6 @@ public:
         return std::string(repr);
     }
 
-    PyObject* return_value() {
-        auto res = run();
-        REQUIRE(res != nullptr);
-        return res;
-    }
-
     PyObject *raises() {
         auto res = run();
         REQUIRE(res == nullptr);
@@ -1500,17 +1494,7 @@ TEST_CASE("Test unpacking with UNPACK_SEQUENCE", "[!mayfail]") {
         auto t = CompilerTest(
                 "def f():\n    a, b = range(2000, 2002)\n    return a, b"
         );
-        PyObject* tuple = t.return_value();
-        REQUIRE(tuple->ob_type == &PyTuple_Type);
-        CHECK(((PyVarObject*)tuple)->ob_size == 2);
-        CHECK(((PyObject*)tuple)->ob_refcnt == 1);
-        auto first = PyTuple_GetItem(tuple, 0);
-        auto second = PyTuple_GetItem(tuple, 1);
-        REQUIRE(first != nullptr);
-        CHECK(first->ob_refcnt == 2);
-        REQUIRE(second != nullptr);
-        CHECK(second->ob_refcnt == 2);
-        Py_DECREF(tuple);
+        CHECK(t.returns() == "(2000, 2001)");
     }
 
     SECTION("test basic unpack again") {

--- a/Tests/test_compiler.cpp
+++ b/Tests/test_compiler.cpp
@@ -339,42 +339,6 @@ TEST_CASE("Test boxing") {
         CHECK(t.returns() == "42");
     }
 }
-TEST_CASE("Test unpacking", "[!mayfail]") {
-    SECTION("Too many items to unpack from list raises valueerror") {
-        auto t = CompilerTest(
-                "def f():\n    x = [1,2,3]\n    a, b = x"
-        );
-        CHECK(t.raises() == PyExc_ValueError);
-    }
-
-    SECTION("Too many items to unpack from tuple raises valueerror") {
-        auto t = CompilerTest(
-                "def f():\n    x = (1,2,3)\n    a, b = x"
-        );
-        CHECK(t.raises() == PyExc_ValueError);
-    }
-
-    SECTION("failure to unpack shouldn't crash, should raise Python exception") {
-        auto t = CompilerTest(
-                "def f():\n    x = [1]\n    a, b, *c = x"
-        );
-        CHECK(t.raises() == PyExc_ValueError);
-    }
-
-    SECTION("unpacking non-iterable shouldn't crash") {
-        auto t = CompilerTest(
-                "def f():\n    a, b, c = len"
-        );
-        CHECK(t.raises() == PyExc_TypeError);
-    }
-
-    SECTION("test") {
-        auto t = CompilerTest(
-                "def f():\n    cs = [('CATEGORY', 'CATEGORY_SPACE')]\n    for op, av in cs:\n        while True:\n            break\n        print(op, av)"
-        );
-        CHECK(t.returns() == "None");
-    }
-}
 
 TEST_CASE("Conditional returns") {
     // +=, -= checks are to avoid constant folding
@@ -1497,89 +1461,138 @@ TEST_CASE("test slicing"){
         CHECK(t.returns() == "[1, 3]");
     }
 }
-TEST_CASE("test unpacking", "[!mayfail]") {
-    SECTION("test basic unpack"){
+TEST_CASE("Test unpacking with UNPACK_SEQUENCE", "[!mayfail]") {
+    SECTION("test basic unpack") {
         auto t = CompilerTest(
-                "def f():\n    a, b = (1, 2)\n    return a + b"
+                "def f():\n    a, b = (1, 2)\n    return a, b"
         );
-        CHECK(t.returns() == "3");
+        CHECK(t.returns() == "(1, 2)");
+    }SECTION("Too many items to unpack from list raises valueerror") {
+        auto t = CompilerTest(
+                "def f():\n    x = [1,2,3]\n    a, b = x"
+        );
+        CHECK(t.raises() == PyExc_ValueError);
     }
 
+    SECTION("Too many items to unpack from tuple raises valueerror") {
+        auto t = CompilerTest(
+                "def f():\n    x = (1,2,3)\n    a, b = x"
+        );
+        CHECK(t.raises() == PyExc_ValueError);
+    }
+
+    SECTION("test unpack from function call") {
+        auto t = CompilerTest(
+                "def f():\n    a, b = range(2)\n    return a, b"
+        );
+        CHECK(t.returns() == "(0, 1)");
+    }
+    SECTION("test multiple assignments by unpack") {
+        auto t = CompilerTest(
+                "def f():\n    a, b = 1, 2\n    return a, b"
+        );
+        CHECK(t.returns() == "(1, 2)");
+    }
+
+    SECTION("unpacking non-iterable shouldn't crash") {
+        auto t = CompilerTest(
+                "def f():\n    a, b, c = len"
+        );
+        CHECK(t.raises() == PyExc_TypeError);
+    }
+
+    SECTION("test unpack for loop") {
+        auto t = CompilerTest(
+                "def f():\n    cs = [('CATEGORY', 'CATEGORY_SPACE')]\n    for op, av in cs:\n        while True:\n            break\n        print(op, av)"
+        );
+        CHECK(t.returns() == "None");
+    }
+}
+
+TEST_CASE("Test unpacking with UNPACK_EX", "[!mayfail]") {
+    SECTION("failure to unpack shouldn't crash, should raise Python exception") {
+    auto t = CompilerTest(
+            "def f():\n    x = [1]\n    a, b, *c = x"
+    );
+    CHECK(t.raises() == PyExc_ValueError);
+    }
     SECTION("test83") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = range(3)\n    return a"
         );
         CHECK(t.returns() == "0");
-    }SECTION("test84") {
+    }
+    SECTION("test84") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = range(3)\n    return b"
         );
         CHECK(t.returns() == "[1]");
-    }SECTION("test85") {
+    }
+    SECTION("test85") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = range(3)\n    return c"
         );
         CHECK(t.returns() == "2");
-    }SECTION("test86") {
+    }
+    SECTION("test86") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = 1, 2, 3\n    return a"
         );
         CHECK(t.returns() == "1");
-    }SECTION("test87") {
+    }
+    SECTION("test87") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = 1, 2, 3\n    return b"
         );
         CHECK(t.returns() == "[2]");
-    }SECTION("test88") {
+    }
+    SECTION("test88") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = 1, 2, 3\n    return c"
         );
         CHECK(t.returns() == "3");
-    }SECTION("test89") {
+    }
+    SECTION("test89") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = 1, 3\n    return c"
         );
         CHECK(t.returns() == "3");
-    }SECTION("test90") {
+    }
+    SECTION("test90") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = 1, 3\n    return b"
         );
         CHECK(t.returns() == "[]");
-    }SECTION("test91") {
+    }
+    SECTION("test91") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = [1, 2, 3]\n    return a"
         );
         CHECK(t.returns() == "1");
-    }SECTION("test92") {
+    }
+    SECTION("test92") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = [1, 2, 3]\n    return b"
         );
         CHECK(t.returns() == "[2]");
-    }SECTION("test * unpack 1") {
+    }
+    SECTION("test * unpack 1") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = [1, 2, 3]\n    return c"
         );
         CHECK(t.returns() == "3");
-    }SECTION("test * unpack 2") {
+    }
+    SECTION("test * unpack 2") {
         auto t = CompilerTest(
-                "def f():\n    a, *b, c = [1, 3]\n    return c"
+                "def f():\n    a, *b, c = [1, 3]\n    return a, b, c"
         );
         CHECK(t.returns() == "3");
-    }SECTION("test * unpack 3") {
+    }
+    SECTION("test * unpack 3") {
         auto t = CompilerTest(
-                "def f():\n    a, *b, c = [1, 3]\n    return b"
+                "def f():\n    a, *b, c = [1, 3]\n    return a, b, c"
         );
         CHECK(t.returns() == "[]");
-    }SECTION("test unpack from function call") {
-        auto t = CompilerTest(
-                "def f():\n    a, b = range(2)\n    return a"
-        );
-        CHECK(t.returns() == "0");
-    }SECTION("test multiple assignments by unpack") {
-        auto t = CompilerTest(
-                "def f():\n    a, b = 1, 2\n    return a"
-        );
-        CHECK(t.returns() == "1");
     }
 }
 TEST_CASE("test classes") {

--- a/Tests/test_compiler.cpp
+++ b/Tests/test_compiler.cpp
@@ -1461,7 +1461,7 @@ TEST_CASE("test slicing"){
         CHECK(t.returns() == "[1, 3]");
     }
 }
-TEST_CASE("Test unpacking with UNPACK_SEQUENCE", "[!mayfail]") {
+TEST_CASE("Test unpacking with UNPACK_SEQUENCE") {
     SECTION("test basic unpack") {
         auto t = CompilerTest(
                 "def f():\n    a, b = (1, 2)\n    return a, b"

--- a/Tests/test_compiler.cpp
+++ b/Tests/test_compiler.cpp
@@ -1498,6 +1498,13 @@ TEST_CASE("test slicing"){
     }
 }
 TEST_CASE("test unpacking", "[!mayfail]") {
+    SECTION("test basic unpack"){
+        auto t = CompilerTest(
+                "def f():\n    a, b = (1, 2)\n    return a + b"
+        );
+        CHECK(t.returns() == "3");
+    }
+
     SECTION("test83") {
         auto t = CompilerTest(
                 "def f():\n    a, *b, c = range(3)\n    return a"

--- a/Tests/test_compiler.cpp
+++ b/Tests/test_compiler.cpp
@@ -1570,7 +1570,7 @@ TEST_CASE("test unpacking", "[!mayfail]") {
                 "def f():\n    a, *b, c = [1, 3]\n    return b"
         );
         CHECK(t.returns() == "[]");
-    }SECTION("test unpack") {
+    }SECTION("test unpack from function call") {
         auto t = CompilerTest(
                 "def f():\n    a, b = range(2)\n    return a"
         );

--- a/src/pyjion/absint.cpp
+++ b/src/pyjion/absint.cpp
@@ -1849,8 +1849,8 @@ AbstactInterpreterCompileResult AbstractInterpreter::compileWorker(PgcStatus pgc
             case UNPACK_SEQUENCE:
                 m_comp->emit_unpack_sequence(oparg, stackInfo.top());
                 decStack();
-                intErrorCheck("failed to unpack");
                 incStack(oparg);
+                intErrorCheck("failed to unpack");
                 break;
             case UNPACK_EX:
                 unpackEx(oparg, curByte); break;

--- a/src/pyjion/absint.cpp
+++ b/src/pyjion/absint.cpp
@@ -1264,9 +1264,7 @@ AbstractSource* AbstractInterpreter::addPgcSource(size_t opcodeIndex) {
  // branches to the current error handler.  Consumes the error code in the process
 void AbstractInterpreter::intErrorCheck(const char* reason, size_t curByte) {
     auto noErr = m_comp->emit_define_label();
-    m_comp->emit_int(0);
-    m_comp->emit_branch(BranchEqual, noErr);
-
+    m_comp->emit_branch(BranchFalse, noErr);
     branchRaise(reason, curByte);
     m_comp->emit_mark_label(noErr);
 }

--- a/src/pyjion/absint.h
+++ b/src/pyjion/absint.h
@@ -416,7 +416,7 @@ private:
 
     void loadFast(int local, size_t opcodeIndex);
     void loadFastWorker(int local, bool checkUnbound, int curByte);
-    void unpackSequence(size_t size, size_t opcode);
+    void unpackSequence(size_t size, size_t opcode, AbstractValueWithSources sources);
 
     void popExcept();
 

--- a/src/pyjion/intrins.cpp
+++ b/src/pyjion/intrins.cpp
@@ -1659,9 +1659,9 @@ PyObject* PyJit_GetIter(PyObject* iterable) {
 
 PyObject* PyJit_IterNext(PyObject* iter) {
     if (iter == nullptr || !PyIter_Check(iter)){
-        PyErr_Format(PyExc_ValueError,
-                     "Invalid iterator given to iternext, got %s - %s at %p.", ObjInfo(iter),
-                     PyUnicode_AsUTF8(PyObject_Repr(iter)), iter);
+        PyErr_Format(PyExc_TypeError,
+                     "Unable to iterate, this type is not iterable. I got %s - %s.", ObjInfo(iter),
+                     PyUnicode_AsUTF8(PyObject_Repr(iter)));
         return nullptr;
     }
 

--- a/src/pyjion/ipycomp.h
+++ b/src/pyjion/ipycomp.h
@@ -240,6 +240,10 @@ public:
     // Stores all of the values on the stack into a tuple
     virtual void emit_tuple_store(size_t size) = 0;
 	virtual void emit_tuple_load(size_t index) = 0;
+    virtual void emit_list_load(size_t index) = 0;
+    virtual void emit_tuple_length() = 0;
+    virtual void emit_list_length() = 0;
+
     // Convert a list to a tuple
     virtual void emit_list_to_tuple() = 0;
 
@@ -305,7 +309,10 @@ public:
     virtual void emit_load_build_class() = 0;
 
     // Unpacks the sequence onto the stack
-    virtual void emit_unpack_sequence(Local sequence, Local sequenceStorage, Label success, size_t size) = 0;
+    virtual void emit_unpack_sequence(size_t size, AbstractValueWithSources iterable) = 0;
+    virtual void emit_unpack_tuple(size_t size, AbstractValueWithSources iterable) = 0;
+    virtual void emit_unpack_list(size_t size, AbstractValueWithSources iterable) = 0;
+    virtual void emit_unpack_generic(size_t size, AbstractValueWithSources iterable) = 0;
     // Unpacks the sequence onto the stack, supporting a remainder list
     virtual void emit_unpack_ex(Local sequence, size_t leftSize, size_t rightSize, Local sequenceStorage, Local list, Local remainder) = 0;
     // Loads an element from the array on the stack

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -251,6 +251,96 @@ Local PythonCompiler::emit_allocate_stack_array(size_t bytes) {
     return sequenceTmp;
 }
 
+void PythonCompiler::emit_unpack_tuple(size_t size, AbstractValueWithSources iterable) {
+    Local t_value = emit_define_local(LK_NativeInt);
+    Label raiseValueError = emit_define_label();
+    Label returnValues = emit_define_label();
+    size_t idx = size;
+    emit_store_local(t_value);
+
+    emit_load_local(t_value);
+    emit_tuple_length();
+    emit_int(size);
+    emit_branch(BranchNotEqual,raiseValueError);
+
+
+    while (idx--) {
+        emit_load_local(t_value);
+        emit_tuple_load(idx);
+        emit_dup();
+        emit_incref();
+    }
+    emit_int(0);
+
+    emit_branch(BranchAlways, returnValues);
+
+    emit_mark_label(raiseValueError);
+    emit_int(-1);
+
+    emit_mark_label(returnValues);
+    emit_load_and_free_local(t_value);
+    decref();
+}
+
+void PythonCompiler::emit_unpack_list(size_t size, AbstractValueWithSources iterable) {
+    Local t_value = emit_define_local(LK_NativeInt);
+    Label raiseValueError = emit_define_label();
+    Label returnValues = emit_define_label();
+    size_t idx = size, idx2 = size;
+
+    emit_store_local(t_value);
+
+    emit_load_local(t_value);
+    emit_list_length();
+    emit_int(size);
+    emit_branch(BranchNotEqual,raiseValueError);
+
+    while (idx--) {
+        emit_load_local(t_value);
+        emit_list_load(idx);
+        emit_dup();
+        emit_incref();
+    }
+    emit_int(0);
+    emit_branch(BranchAlways, returnValues);
+
+    emit_mark_label(raiseValueError);
+    emit_int(-1);
+
+    emit_mark_label(returnValues);
+    emit_load_and_free_local(t_value);
+    decref();
+}
+
+void PythonCompiler::emit_unpack_generic(size_t size, AbstractValueWithSources iterable) {
+    Local t_value = emit_define_local(LK_NativeInt);
+    emit_store_local(t_value);
+
+    size_t idx = size;
+    while (idx--) {
+        emit_load_local(t_value);
+        m_il.ld_i8(idx);
+        m_il.emit_call(METHOD_SUBSCR_OBJ_I);
+        emit_dup();
+        emit_incref();
+    }
+    emit_load_and_free_local(t_value);
+    decref();
+}
+
+void PythonCompiler::emit_unpack_sequence(size_t size, AbstractValueWithSources iterable) {
+    if (iterable.Value->known()) {
+        switch (iterable.Value->kind()) {
+            case AVK_Tuple:
+                return emit_unpack_tuple(size, iterable);
+            case AVK_List:
+                return emit_unpack_list(size, iterable);
+            default:
+                return emit_unpack_generic(size, iterable);
+        }
+    }
+    return emit_unpack_generic(size, iterable);
+}
 
 /************************************************************************
  * Compiler interface implementation
@@ -745,6 +835,25 @@ void PythonCompiler::emit_tuple_load(size_t index) {
 	m_il.ld_ind_i();
 }
 
+void PythonCompiler::emit_tuple_length(){
+    m_il.ld_i(offsetof(PyVarObject, ob_size));
+    m_il.add();
+    m_il.ld_ind_i();
+}
+
+void PythonCompiler::emit_list_load(size_t index) {
+    m_il.ld_i(index * sizeof(size_t) + offsetof(PyListObject, ob_item));
+    m_il.add();
+    m_il.ld_ind_i();
+}
+
+void PythonCompiler::emit_list_length(){
+    m_il.ld_i(offsetof(PyVarObject, ob_size));
+    m_il.add();
+    m_il.ld_ind_i();
+}
+
+
 void PythonCompiler::emit_tuple_store(size_t argCnt) {
     /// This function emits a tuple from the stack, only using borrowed references.
     auto valueTmp = m_il.define_local(Parameter(CORINFO_TYPE_NATIVEINT));
@@ -1052,22 +1161,6 @@ void PythonCompiler::emit_import_star() {
 void PythonCompiler::emit_load_build_class() {
     load_frame();
     m_il.emit_call(METHOD_GETBUILDCLASS_TOKEN);
-}
-
-void PythonCompiler::emit_unpack_sequence(Local sequence, Local sequenceStorage, Label success, size_t size) {
-    // load the iterable, the count, and our temporary
-    // storage if we need to iterate over the object.
-    m_il.ld_loc(sequence);
-    m_il.ld_i(size);
-    m_il.ld_loc(sequenceStorage);
-    m_il.emit_call(METHOD_UNPACK_SEQUENCE_TOKEN);
-
-    m_il.dup();
-    m_il.load_null();
-    m_il.branch(BranchNotEqual, success);
-    m_il.pop();
-    m_il.ld_loc(sequence);
-    decref();
 }
 
 void PythonCompiler::emit_load_array(int index) {

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -365,13 +365,11 @@ void PythonCompiler::emit_unpack_generic(size_t size, AbstractValueWithSources i
         emit_load_local(iterated[i]);
     emit_load_and_free_local(t_iter);
     decref();
-    emit_load_and_free_local(t_object);
-    decref();
     emit_load_and_free_local(result);
 }
 
 void PythonCompiler::emit_unpack_sequence(size_t size, AbstractValueWithSources iterable) {
-    if (iterable.Value->known()) {
+    if (iterable.Value->known() && !iterable.Value->needsGuard()) {
         switch (iterable.Value->kind()) {
             case AVK_Tuple:
                 return emit_unpack_tuple(size, iterable);

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -263,23 +263,23 @@ void PythonCompiler::emit_unpack_tuple(size_t size, AbstractValueWithSources ite
     emit_int(size);
     emit_branch(BranchNotEqual,raiseValueError);
 
+        while (idx--) {
+            emit_load_local(t_value);
+            emit_tuple_load(idx);
+            emit_dup();
+            emit_incref();
+        }
+        emit_int(0);
 
-    while (idx--) {
-        emit_load_local(t_value);
-        emit_tuple_load(idx);
-        emit_dup();
-        emit_incref();
-    }
-    emit_int(0);
-
-    emit_branch(BranchAlways, returnValues);
+        emit_branch(BranchAlways, returnValues);
 
     emit_mark_label(raiseValueError);
-    while (idx2--){
-        emit_null();
-    }
-    emit_pyerr_setstring(PyExc_ValueError, "Cannot unpack due to size mismatch");
-    emit_int(-1);
+
+        while (idx2--){
+            emit_null();
+        }
+        emit_pyerr_setstring(PyExc_ValueError, "Cannot unpack due to size mismatch");
+        emit_int(-1);
 
     emit_mark_label(returnValues);
     emit_load_and_free_local(t_value);
@@ -348,7 +348,7 @@ void PythonCompiler::emit_unpack_generic(size_t size, AbstractValueWithSources i
             emit_branch(BranchAlways, endbranch);
 
         emit_mark_label(success);
-            // Success
+            // Success, Py_INCREF
             emit_dup();
             emit_incref();
 
@@ -357,7 +357,8 @@ void PythonCompiler::emit_unpack_generic(size_t size, AbstractValueWithSources i
     }
     for (int i = 0; i < size ; i++)
         emit_load_local(iterated[i]);
-
+    emit_load_and_free_local(t_iter);
+    decref();
     emit_load_and_free_local(t_object);
     decref();
     emit_load_and_free_local(result);

--- a/src/pyjion/pycomp.cpp
+++ b/src/pyjion/pycomp.cpp
@@ -340,13 +340,18 @@ void PythonCompiler::emit_unpack_generic(size_t size, AbstractValueWithSources i
 
         m_il.dup();
         emit_null();
+
         emit_branch(BranchNotEqual, success);
-        emit_int(-1);
-        emit_store_local(result);
-        emit_branch(BranchAlways, endbranch);
+            // Failure
+            emit_int(1);
+            emit_store_local(result);
+            emit_branch(BranchAlways, endbranch);
+
         emit_mark_label(success);
-        emit_dup();
-        emit_incref();
+            // Success
+            emit_dup();
+            emit_incref();
+
         emit_mark_label(endbranch);
     }
 

--- a/src/pyjion/pycomp.h
+++ b/src/pyjion/pycomp.h
@@ -307,6 +307,9 @@ public:
     void emit_new_tuple(size_t size) override;
     void emit_tuple_store(size_t size) override;
     void emit_tuple_load(size_t index) override;
+    void emit_list_load(size_t index) override;
+    void emit_tuple_length() override;
+    void emit_list_length() override;
 
     void emit_new_list(size_t argCnt) override;
     void emit_list_store(size_t argCnt) override;
@@ -352,7 +355,10 @@ public:
 
     void emit_load_build_class() override;
 
-    void emit_unpack_sequence(Local sequence, Local sequenceStorage, Label success, size_t size) override;
+    void emit_unpack_sequence(size_t size, AbstractValueWithSources iterable) override;
+    void emit_unpack_tuple(size_t size, AbstractValueWithSources iterable) override;
+    void emit_unpack_list(size_t size, AbstractValueWithSources iterable) override;
+    void emit_unpack_generic(size_t size, AbstractValueWithSources iterable) override;
     void emit_load_array(int index) override;
     void emit_store_to_array(Local array, int index) override;
 


### PR DESCRIPTION
* Remove the use of the LOCALLOC (alloca) opcode for .NET
* Create an optimized path for both tuples and lists
* Inline a size comparison and raise ValueError
* Do a fast check for NoneType on the utterable
* Implement a generic path for any iterable
Closes #225 
