### PR TITLE
[WIP] Create a custom memory allocator that uses execution profiles to create custom pools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ if(NET_SRC_LIB)  # use the libraries compiled from source
 
 endif()
 
-set(SOURCES src/pyjion/absint.cpp src/pyjion/absvalue.cpp src/pyjion/intrins.cpp src/pyjion/jitinit.cpp src/pyjion/pycomp.cpp src/pyjion/pyjit.cpp src/pyjion/exceptionhandling.cpp src/pyjion/stack.cpp src/pyjion/block.cpp src/pyjion/pyjitmath.cpp src/pyjion/pyjitmath.h src/pyjion/codemodel.cpp src/pyjion/binarycomp.cpp)
+set(SOURCES src/pyjion/absint.cpp src/pyjion/absvalue.cpp src/pyjion/intrins.cpp src/pyjion/jitinit.cpp src/pyjion/pycomp.cpp src/pyjion/pyjit.cpp src/pyjion/exceptionhandling.cpp src/pyjion/stack.cpp src/pyjion/block.cpp src/pyjion/pyjitmath.cpp src/pyjion/codemodel.cpp src/pyjion/binarycomp.cpp src/pyjion/pgocodeprofile.cpp src/pyjion/pyjitallocator.cpp)
 
 if (WIN32)
     enable_language(ASM_MASM)

--- a/Tests/benchmarks/test_nbody.py
+++ b/Tests/benchmarks/test_nbody.py
@@ -127,8 +127,5 @@ if __name__ == "__main__":
     import pyjion.dis
     import dis
     print(dis.dis(advance))
-    # print(pyjion.dis.dis(advance))
-    print(pyjion.info(offset_momentum))
-    print(pyjion.info(advance))
-    print(pyjion.info(report_energy))
+    print(pyjion.dis.dis(advance))
     gc.collect()

--- a/src/pyjion/pgocodeprofile.cpp
+++ b/src/pyjion/pgocodeprofile.cpp
@@ -67,8 +67,12 @@ PyObject* PyjionCodeProfile::getValue(size_t opcodePosition, size_t stackPositio
     return this->stackValues[opcodePosition][stackPosition];
 }
 
-void PyjionCodeProfile::captureMalloc(size_t size) {
+void PyjionCodeProfile::captureMalloc(size_t executionCount, size_t size) {
     this->allocations[size] += 1;
+}
+
+unordered_map<size_t, size_t> PyjionCodeProfile::getAllocations() {
+    return allocations;
 }
 
 void capturePgcStackValue(PyjionCodeProfile* profile, PyObject* value, size_t opcodePosition, int stackPosition){

--- a/src/pyjion/pgocodeprofile.cpp
+++ b/src/pyjion/pgocodeprofile.cpp
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "pgocodeprofile.h"
+
+PgcStatus nextPgcStatus(PgcStatus status){
+    switch(status){
+        case PgcStatus::Uncompiled: return PgcStatus::CompiledWithProbes;
+        case PgcStatus::CompiledWithProbes:
+        case PgcStatus::Optimized:
+        default:
+            return PgcStatus::Optimized;
+    }
+}
+
+PyjionCodeProfile::~PyjionCodeProfile() {
+    for (auto &pos: this->stackTypes) {
+        for(auto &observed: pos.second){
+            Py_XDECREF(observed.second);
+        }
+    }
+    for (auto &pos: this->stackValues) {
+        for(auto &observed: pos.second){
+            Py_XDECREF(observed.second);
+        }
+    }
+}
+
+void PyjionCodeProfile::record(size_t opcodePosition, size_t stackPosition, PyObject* value){
+    if (this->stackTypes[opcodePosition][stackPosition] == nullptr) {
+        this->stackTypes[opcodePosition][stackPosition] = Py_TYPE(value);
+        Py_INCREF(Py_TYPE(value));
+    }
+    if (this->stackValues[opcodePosition][stackPosition] == nullptr) {
+        this->stackValues[opcodePosition][stackPosition] = value;
+        Py_INCREF(value);
+    }
+}
+
+PyTypeObject* PyjionCodeProfile::getType(size_t opcodePosition, size_t stackPosition) {
+    return this->stackTypes[opcodePosition][stackPosition];
+}
+
+PyObject* PyjionCodeProfile::getValue(size_t opcodePosition, size_t stackPosition) {
+    return this->stackValues[opcodePosition][stackPosition];
+}
+
+void PyjionCodeProfile::captureMalloc(size_t size) {
+    this->allocations[size] += 1;
+}
+
+void capturePgcStackValue(PyjionCodeProfile* profile, PyObject* value, size_t opcodePosition, int stackPosition){
+    if (value != nullptr && profile != nullptr){
+        profile->record(opcodePosition, stackPosition, value);
+    }
+}

--- a/src/pyjion/pgocodeprofile.h
+++ b/src/pyjion/pgocodeprofile.h
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef PYJION_PGOCODEPROFILE
+#define PYJION_PGOCODEPROFILE
+
+#include <Python.h>
+#include <unordered_map>
+
+using namespace std;
+
+/* Jitted code object.  This object is returned from the JIT implementation.  The JIT can allocate
+a jitted code object and fill in the state for which is necessary for it to perform an evaluation. */
+enum PgcStatus {
+    Uncompiled = 0,
+    CompiledWithProbes = 1,
+    Optimized = 2
+};
+
+PgcStatus nextPgcStatus(PgcStatus status);
+
+class PyjionCodeProfile{
+    unordered_map<size_t, unordered_map<size_t, PyTypeObject *>> stackTypes;
+    unordered_map<size_t, unordered_map<size_t, PyObject *>> stackValues;
+    unordered_map<size_t, size_t> allocations;
+public:
+    void record(size_t opcodePosition, size_t stackPosition, PyObject* obj);
+    PyTypeObject* getType(size_t opcodePosition, size_t stackPosition);
+    PyObject* getValue(size_t opcodePosition, size_t stackPosition);
+    PgcStatus status = Uncompiled;
+    void captureMalloc(size_t size);
+    ~PyjionCodeProfile();
+};
+
+void capturePgcStackValue(PyjionCodeProfile* profile, PyObject* value, size_t opcodePosition, int stackPosition);
+
+#endif //PYJION_PGOCODEPROFILE

--- a/src/pyjion/pgocodeprofile.h
+++ b/src/pyjion/pgocodeprofile.h
@@ -50,7 +50,8 @@ public:
     PyTypeObject* getType(size_t opcodePosition, size_t stackPosition);
     PyObject* getValue(size_t opcodePosition, size_t stackPosition);
     PgcStatus status = Uncompiled;
-    void captureMalloc(size_t size);
+    void captureMalloc(size_t executionCount, size_t size);
+    unordered_map<size_t, size_t> getAllocations();
     ~PyjionCodeProfile();
 };
 

--- a/src/pyjion/pyjit.cpp
+++ b/src/pyjion/pyjit.cpp
@@ -114,9 +114,8 @@ static inline PyObject* PyJit_ExecuteJittedFrame(void* state, PyFrameObject*fram
     try {
         // Set allocator
         Pyjit_SetAllocatorProfile(profile);
-
         auto res = ((Py_EvalFunc)state)(nullptr, frame, tstate, profile);
-
+        Pyjit_UnsetAllocatorProfile();
         Pyjit_LeaveRecursiveCall();
         frame->f_executing = 0;
         return res;

--- a/src/pyjion/pyjit.cpp
+++ b/src/pyjion/pyjit.cpp
@@ -112,10 +112,10 @@ static inline PyObject* PyJit_ExecuteJittedFrame(void* state, PyFrameObject*fram
 
 	frame->f_executing = 1;
     try {
-        // Set allocator
-        Pyjit_SetAllocatorProfile(profile);
+        Pyjit_AllocatorProfile allocatorProfile = Pyjit_InitAllocator(profile, 1);
+        Pyjit_SetAllocatorContext(&allocatorProfile);
         auto res = ((Py_EvalFunc)state)(nullptr, frame, tstate, profile);
-        Pyjit_UnsetAllocatorProfile();
+        Pyjit_ResetAllocatorContext();
         Pyjit_LeaveRecursiveCall();
         frame->f_executing = 0;
         return res;

--- a/src/pyjion/pyjit.h
+++ b/src/pyjion/pyjit.h
@@ -48,20 +48,10 @@
 #include <frameobject.h>
 #include <Python.h>
 
+#include "pgocodeprofile.h"
+
 using namespace std;
 
-class PyjionCodeProfile{
-    unordered_map<size_t, unordered_map<size_t, PyTypeObject *>> stackTypes;
-    unordered_map<size_t, unordered_map<size_t, PyObject *>> stackValues;
-public:
-    void record(size_t opcodePosition, size_t stackPosition, PyObject* obj);
-    PyTypeObject* getType(size_t opcodePosition, size_t stackPosition);
-    PyObject* getValue(size_t opcodePosition, size_t stackPosition);
-    ~PyjionCodeProfile();
-};
-
-
-void capturePgcStackValue(PyjionCodeProfile* profile, PyObject* value, size_t opcodePosition, int stackPosition);
 class PyjionJittedCode;
 
 bool JitInit();
@@ -111,17 +101,6 @@ void PyjionJitFree(void* obj);
 int Pyjit_CheckRecursiveCall(PyThreadState *tstate, const char *where);
 static int Pyjit_EnterRecursiveCall(const char *where);
 static void Pyjit_LeaveRecursiveCall();
-
-
-/* Jitted code object.  This object is returned from the JIT implementation.  The JIT can allocate
-a jitted code object and fill in the state for which is necessary for it to perform an evaluation. */
-enum PgcStatus {
-    Uncompiled = 0,
-    CompiledWithProbes = 1,
-    Optimized = 2
-};
-
-PgcStatus nextPgcStatus(PgcStatus status);
 
 class PyjionJittedCode {
 public:

--- a/src/pyjion/pyjitallocator.cpp
+++ b/src/pyjion/pyjitallocator.cpp
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "pyjitallocator.h"
+
+static PyMemAllocatorEx g_originalAllocator ; // Whichever allocator was set before JIT was enabled.
+
+static void *
+_PyJit_Malloc(void *ctx, size_t size)
+{
+    if (ctx != nullptr) {
+        PyjionCodeProfile* profile = static_cast<PyjionCodeProfile*>(ctx);
+        profile->captureMalloc(size);
+    }
+    return g_originalAllocator.malloc(nullptr, size);
+}
+
+static void *
+_PyJit_Calloc(void *ctx, size_t nelem, size_t elsize)
+{
+    return g_originalAllocator.calloc(nullptr, nelem, elsize);
+}
+
+static void *
+_PyJit_Realloc(void *ctx, void *ptr, size_t size)
+{
+    return g_originalAllocator.realloc(nullptr, ptr, size);
+}
+
+static void
+_PyJit_Free(void *ctx, void *ptr)
+{
+    g_originalAllocator.free(nullptr, ptr);
+}
+
+static PyMemAllocatorEx PYJIT_ALLOC = {NULL, _PyJit_Malloc, _PyJit_Calloc, _PyJit_Realloc, _PyJit_Free};
+
+void Pyjit_SetAllocatorProfile(PyjionCodeProfile* profile) {
+    PYJIT_ALLOC.ctx = profile;
+    PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &PYJIT_ALLOC);
+}
+
+void Pyjit_AllocatorInit(){
+    PyMem_GetAllocator(PYMEM_DOMAIN_OBJ, &g_originalAllocator);
+    PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &PYJIT_ALLOC);
+}

--- a/src/pyjion/pyjitallocator.cpp
+++ b/src/pyjion/pyjitallocator.cpp
@@ -62,6 +62,11 @@ void Pyjit_SetAllocatorProfile(PyjionCodeProfile* profile) {
     PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &PYJIT_ALLOC);
 }
 
+void Pyjit_UnsetAllocatorProfile() {
+    PYJIT_ALLOC.ctx = nullptr;
+    PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &PYJIT_ALLOC);
+}
+
 void Pyjit_AllocatorInit(){
     PyMem_GetAllocator(PYMEM_DOMAIN_OBJ, &g_originalAllocator);
     PyMem_SetAllocator(PYMEM_DOMAIN_OBJ, &PYJIT_ALLOC);

--- a/src/pyjion/pyjitallocator.h
+++ b/src/pyjion/pyjitallocator.h
@@ -29,6 +29,8 @@
 #include <Python.h>
 #include "pgocodeprofile.h"
 
+#define NPOOLSOPTIMIZE 10
+
 typedef struct {
     uintptr_t address;
     uintptr_t ceiling;
@@ -37,8 +39,10 @@ typedef struct {
 
 typedef struct {
     PyjionCodeProfile* profile;
-    size_t executionCount;
-    unordered_map<size_t, Pyjit_AllocatorPool> pools;
+    size_t executions;
+    size_t n_pools;
+    size_t pool_sizes[NPOOLSOPTIMIZE];
+    Pyjit_AllocatorPool pools[NPOOLSOPTIMIZE];
 } Pyjit_AllocatorProfile;
 
 static void * _PyJit_Malloc(void *ctx, size_t size);

--- a/src/pyjion/pyjitallocator.h
+++ b/src/pyjion/pyjitallocator.h
@@ -36,6 +36,8 @@ static void * _PyJit_Realloc(void *ctx, void *ptr, size_t size);
 static void _PyJit_Free(void *ctx, void *ptr);
 
 void Pyjit_SetAllocatorProfile(PyjionCodeProfile* profile);
+void Pyjit_UnsetAllocatorProfile();
+
 void Pyjit_AllocatorInit();
 
 #endif //SRC_PYJION_PYJITALLOCATOR_H

--- a/src/pyjion/pyjitallocator.h
+++ b/src/pyjion/pyjitallocator.h
@@ -29,15 +29,27 @@
 #include <Python.h>
 #include "pgocodeprofile.h"
 
+typedef struct {
+    uintptr_t address;
+    uintptr_t ceiling;
+    size_t allocated;
+} Pyjit_AllocatorPool;
+
+typedef struct {
+    PyjionCodeProfile* profile;
+    size_t executionCount;
+    unordered_map<size_t, Pyjit_AllocatorPool> pools;
+} Pyjit_AllocatorProfile;
+
 static void * _PyJit_Malloc(void *ctx, size_t size);
 static void * _PyJit_Calloc(void *ctx, size_t nelem, size_t elsize);
 static void * _PyJit_Realloc(void *ctx, void *ptr, size_t size);
 
 static void _PyJit_Free(void *ctx, void *ptr);
 
-void Pyjit_SetAllocatorProfile(PyjionCodeProfile* profile);
-void Pyjit_UnsetAllocatorProfile();
-
+void Pyjit_SetAllocatorContext(Pyjit_AllocatorProfile * profile);
+void Pyjit_ResetAllocatorContext();
+Pyjit_AllocatorProfile Pyjit_InitAllocator(PyjionCodeProfile* profile, size_t execCnt);
 void Pyjit_AllocatorInit();
 
 #endif //SRC_PYJION_PYJITALLOCATOR_H

--- a/src/pyjion/pyjitallocator.h
+++ b/src/pyjion/pyjitallocator.h
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef SRC_PYJION_PYJITALLOCATOR_H
+#define SRC_PYJION_PYJITALLOCATOR_H
+
+#include <Python.h>
+#include "pgocodeprofile.h"
+
+static void * _PyJit_Malloc(void *ctx, size_t size);
+static void * _PyJit_Calloc(void *ctx, size_t nelem, size_t elsize);
+static void * _PyJit_Realloc(void *ctx, void *ptr, size_t size);
+
+static void _PyJit_Free(void *ctx, void *ptr);
+
+void Pyjit_SetAllocatorProfile(PyjionCodeProfile* profile);
+void Pyjit_AllocatorInit();
+
+#endif //SRC_PYJION_PYJITALLOCATOR_H


### PR DESCRIPTION
This is just a half-baked idea at the moment. 

* See the sizes of objects that a code-object needed
* (Maybe) check the existing arenas to see what size pools are available with space
* Pre-allocated custom pools for the sizes captured on the second compile phase