### PR TITLE
Optimizations table now reflect that OPT-4 is enabled by default

### DIFF
--- a/Docs/source/optimizations.rst
+++ b/Docs/source/optimizations.rst
@@ -118,8 +118,8 @@ Optimization Matrix
      - On
    * - :ref:`OPT-4`
      - Off
-     - Off
-     - Off
+     - On
+     - On
    * - :ref:`OPT-5`
      - Off
      - On


### PR DESCRIPTION
According to the documentation (See https://pyjion.readthedocs.io/en/latest/opt/opt-4.html#configuration), OPT-4 is enabled when the optimization level is at least 1.
This contradicts what is specified in the table.

This commit fixes just that.