### PR TITLE
Fix a bug where the contains operation wasn't being checked for null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 1.0.0 (master)
+
+* Fixed a bug where `in` (CONTAINS_OP) result wasn't being checked for exceptions and the next operation would segfault if the `in` operation returned an error result.
+
 ## 1.0.0 (beta6)
 
 * Updated to .NET 6 preview 6

--- a/Tests/test_basics.cpp
+++ b/Tests/test_basics.cpp
@@ -298,6 +298,15 @@ TEST_CASE("General contains comparison") {
         auto t = EmissionTest("def f(): return 'i' not in 'team'");
         CHECK(t.returns() == "True");
     }
+    SECTION("not in fault case") {
+        auto t = EmissionTest("def f():\n"
+                              " x = [0, 1, 2]\n"
+                              " if x not in 'team':\n"
+                              "   return True\n"
+                              " else:\n"
+                              "   return False\n");
+        CHECK(t.raises() == PyExc_TypeError);
+    }
 }
 
 TEST_CASE("Assertions") {

--- a/src/pyjion/absint.cpp
+++ b/src/pyjion/absint.cpp
@@ -2445,6 +2445,7 @@ AbstactInterpreterCompileResult AbstractInterpreter::compileWorker(PgcStatus pgc
                 else
                     m_comp->emit_not_in();
                 decStack(2); // in/not in takes two
+                errorCheck("in failed", curByte);
                 incStack(); // pushes result
                 break;
             }


### PR DESCRIPTION
Fix a bug where the contains operation wasn't being checked for null values (in keyword)