### PR TITLE
Add a Dependabot config to keep GitHub action versions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
GitHub CI runs are throwing deprecation warnings and errors ([recent example](https://github.com/tonybaloney/Pyjion/actions/runs/6391236660)). This can be fixed by updating the action versions, e.g. updating `actions/checkout@v2` to `v4`.

Rather than updating the actions once, this PR introduces a Dependabot config that will regularly check for new action versions and submit PRs to update the versions.

If this PR merges, you can expect Dependabot to immediately open multiple PRs that target each out-of-date action version.

Thanks for your work on Pyjion!