### PR TITLE
CI: adding Python 3.11

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,16 +2,16 @@ name: Benchmarks
 
 on:
   push:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
   pull_request:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
 
 jobs:
   bench-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
         dot-net-version: [ "7.0.100" ]
 
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
   pull_request:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
   schedule:
     - cron: '34 9 * * 2'
 
@@ -31,6 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'cpp' ]
+        python-version: ["3.10", "3.11"]
         dot-net-version: [ "7.0.100" ]
 
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
@@ -55,7 +56,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Install CLR requirements
       run: |

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,9 +1,9 @@
 name: "Maintenance"
 on:
   push:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
   pull_request:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
 
 jobs:
   build:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,9 +2,9 @@ name: Compile and test C++ package
 
 on:
   push:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
   pull_request:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
 
 env:
   BUILD_TYPE: Release
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
         dot-net-version: [ "7.0.100" ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,7 +1,9 @@
-name: Build
+name: Build wheels
 
 on:
   push:
+    branches: [ develop/main ]
+  pull_request:
     branches: [ develop/main ]
 
 jobs:
@@ -10,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-11", ubuntu-20.04, "windows-latest"]
+        os: ["macos-12", "ubuntu-20.04", "windows-2022"]
 
     steps:
       - uses: actions/checkout@v4
@@ -25,5 +27,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
 
       - uses: actions/upload-artifact@v4
+        if: github.event_name != 'pull_request'
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ develop/main, develop/3.10 ]
+    branches: [ develop/main ]
 
 jobs:
   build_wheels:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     package_dir={"": "src"},
     setup_requires=setup_requires,
     extras_require={"dis": ["rich>=11.0", "distorm3"]},
-    python_requires="==3.10.*",
+    python_requires=">=3.10, <3.12",
     include_package_data=True,
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
By my understanding the latest py3.11 and 3.12 are missing as at the tome of the last release, these Python versions have not existed, so I would try just naive adding py3.11 to the CI if all tests are passing... :rabbit: 